### PR TITLE
TASK-43200 Load PerkStore application when DOM is loaded

### DIFF
--- a/perk-store-webapps/src/main/webapp/perkstore.html
+++ b/perk-store-webapps/src/main/webapp/perkstore.html
@@ -15,5 +15,11 @@ along with this program; if not, write to the Free Software Foundation,
 Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 -->
 <div class="VuetifyApp">
-  <div id="PerkStoreApp"></div>
+  <div data-app="true"
+    class="v-application v-application--is-ltr theme--light"
+    id="PerkStoreApp" flat="">
+    <script>
+      require(['PORTLET/perk-store/PerkStore'], app => app.init())
+    </script>
+  </div>
 </div>

--- a/perk-store-webapps/src/main/webapp/vue-app/perk-store.js
+++ b/perk-store-webapps/src/main/webapp/vue-app/perk-store.js
@@ -23,10 +23,12 @@ const vuetify = new Vuetify(eXo.env.portal.vuetifyPreset);
 const lang = (eXo && eXo.env && eXo.env.portal && eXo.env.portal.language) || 'en';
 const url = `${eXo.env.portal.context}/${eXo.env.portal.rest}/i18n/bundle/locale.addon.PerkStore-${lang}.json`;
 
-exoi18n.loadLanguageAsync(lang, url).then(i18n => {
-  new Vue({
-    render: (h) => h(PerkStoreApp),
-    i18n,
-    vuetify,
-  }).$mount('#PerkStoreApp');
-});
+export function init() {
+  exoi18n.loadLanguageAsync(lang, url).then(i18n => {
+    new Vue({
+      render: (h) => h(PerkStoreApp),
+      i18n,
+      vuetify,
+    }).$mount('#PerkStoreApp');
+  });
+}


### PR DESCRIPTION
This modification is related to Meeds-io/gatein-portal#197

Prior to this change, the perkstore application wasn't loaded as done for other Vue apps, so that when editing page layout or having the `InPage navigation` feature enabled, the perk store isn't displayed the second time we access it.