### PR TITLE
Task-48388  Add link to the perkstore order widget on snapshot page

### DIFF
--- a/perk-store-webapps/src/main/webapp/WEB-INF/jsp/perkstoreOrder.jsp
+++ b/perk-store-webapps/src/main/webapp/WEB-INF/jsp/perkstoreOrder.jsp
@@ -36,7 +36,7 @@
                   </div>
                 </div>
                 <div class="flex d-flex xs12 justify-center pa-2">
-                  <a class="display-1 font-weight-bold big-number">
+                  <a href="/portal/dw/perkstore/myorders" class="display-1 font-weight-bold big-number">
                     <%=totalOrders%><span class="mt-4 ms-1 product-label"><%=titleOrders%></span>
                   </a>
                 </div>


### PR DESCRIPTION
Task-48388  Add link to the perkstore order widget on snapshot page 

When clicking on perk-store order widget on snapshot page there is nothing happened, So we add link to open My order view when clicking on it