### PR TITLE
Task-48394 Add label to reset filter button

### DIFF
--- a/perk-store-services/src/main/resources/locale/addon/PerkStore_en.properties
+++ b/perk-store-services/src/main/resources/locale/addon/PerkStore_en.properties
@@ -251,6 +251,7 @@ exoplatform.perkstore.button.deliver=Deliver
 exoplatform.perkstore.button.delete=Delete
 exoplatform.perkstore.button.cancel=Cancel
 exoplatform.perkstore.button.refresh=Refresh
+exoplatform.perkstore.button.reset=Reset
 exoplatform.perkstore.button.search=Search
 exoplatform.perkstore.button.download=Download
 exoplatform.perkstore.button.loadMore=Load more

--- a/perk-store-webapps/src/main/webapp/vue-app/components/perk-store/OrdersFilter.vue
+++ b/perk-store-webapps/src/main/webapp/vue-app/components/perk-store/OrdersFilter.vue
@@ -70,7 +70,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
           @click="reset">
           <template>
             <i class="fas fa-redo"></i>
-            {{ $t('popup.reset') }}
+            {{ $t('exoplatform.perkstore.button.reset') }}
           </template>
         </v-btn>
         <v-spacer />


### PR DESCRIPTION
Task-48394 Add label to reset filter button

The label of the button reset filter in Advanced filter order drawer is not displaying, in this PR we add a new label for this button in the properties files.