### PR TITLE
TASK-47108 : Remove 'Wallet password' label when password is saved on browser

### DIFF
--- a/perk-store-webapps/src/main/webapp/vue-app/components/perk-store/BuyForm.vue
+++ b/perk-store-webapps/src/main/webapp/vue-app/components/perk-store/BuyForm.vue
@@ -115,7 +115,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
         </v-col>
       </v-row>
       <v-row class="pl-5">
-        <label class="font-weight-bold">{{ $t('exoplatform.perkstore.label.walletPassword') }}</label>
+        <label v-if="needPassword" class="font-weight-bold">{{ $t('exoplatform.perkstore.label.walletPassword') }}</label>
       </v-row>
       <v-row class="pl-5">
         <v-text-field


### PR DESCRIPTION
'Wallet password' label still displayed when the password is saved on browser
fixed by adding v-if condition 