### PR TITLE
52301 : Fix perk store admin application

### DIFF
--- a/perk-store-services/src/main/resources/locale/addon/PerkStore_en.properties
+++ b/perk-store-services/src/main/resources/locale/addon/PerkStore_en.properties
@@ -266,3 +266,7 @@ exoplatform.perkstore.button.disabledBuyButton=You can't buy your own product
 exoplatform.perkstore.img.alt=Avatar of {0}
 
 search.connector.label.perkstore=Products
+
+
+exoplatform.perkstore.admin.settings.success=Perks settings were saved successfully !
+exoplatform.perkstore.admin.settings.error=Error caught when saving Perkstore settings : {0}

--- a/perk-store-webapps/src/main/webapp/WEB-INF/gatein-resources.xml
+++ b/perk-store-webapps/src/main/webapp/WEB-INF/gatein-resources.xml
@@ -107,6 +107,10 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
       <depends>
         <module>extensionRegistry</module>
       </depends>
+      <depends>
+        <module>commons-cometd3</module>
+        <as>cCometd</as>
+      </depends>
     </module>
   </portlet>
 


### PR DESCRIPTION
Perks administration application was not working, when we click on save nothing happens and when we reload page the fields became empty again.
This fix makes sure to reload the saved settings when opening the administration page, and added alert messages for successful and erroneous saving operations with new Vue alert component instead of old basic one.