### PR TITLE
TASK-53835 Rename Search connector for better analytics identification

### DIFF
--- a/perk-store-webapps/src/main/webapp/WEB-INF/conf/perk-store/search-configuration.xml
+++ b/perk-store-webapps/src/main/webapp/WEB-INF/conf/perk-store/search-configuration.xml
@@ -33,7 +33,7 @@
           <description>Search connector for perk store products</description>
           <object type="org.exoplatform.social.core.search.SearchConnector">
             <field name="name">
-              <string>perkstore</string>
+              <string>products</string>
             </field>
             <field name="uri">
               <string><![CDATA[/portal/rest/perkstore/api/product]]></string>


### PR DESCRIPTION
Prior to this change, the name of Perk Store Products search connector was 'perkstore' which is not convenient knowing that this is about products search only. Thus, to make sure to make the connector name more clear in analytics, the name has been renamed to 'products'.