### PR TITLE
TASK-56089: fix displaying the same merchant name on all products details drawer

### DIFF
--- a/perk-store-webapps/src/main/webapp/vue-app/components/perk-store/BuyForm.vue
+++ b/perk-store-webapps/src/main/webapp/vue-app/components/perk-store/BuyForm.vue
@@ -61,8 +61,9 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
           <v-row class="pb-3">
             <label class="font-weight-bold">{{ $t('exoplatform.perkstore.label.Marchant') }}:</label>
           </v-row>
-          <v-row v-if="product.creator" class="pb-3">
+          <v-row v-if="product && product.receiverMarchand" class="pb-3">
             <exo-user-avatar
+              :key="product.receiverMarchand.id"
               :profile-id="product.receiverMarchand.id"
               :size="25"
               extra-class="buyFormMarchant"


### PR DESCRIPTION
the same product merchant name is displayed on all product details because the exo-user-avatar component displays the first selected data.
Added attribute key to force the changes when the data changes