### PR TITLE
TASK-55390: fix wrong redirection to order notificaion

### DIFF
--- a/perk-store-webapps/src/main/webapp/vue-app/components/PerkStoreApp.vue
+++ b/perk-store-webapps/src/main/webapp/vue-app/components/PerkStoreApp.vue
@@ -366,7 +366,7 @@ export default {
     },
     loading() {
       if (!this.loading) {
-        const urlPath = document.location.search;
+        const urlPath = document.location.search || document.location.pathname;
         const productId = urlPath.match( /\d+/ ) && urlPath.match( /\d+/ ).join('');
         if (urlPath === `${eXo.env.portal.context}/${eXo.env.portal.portalName}/perkstore/catalog`) {
           this.tab = 0;


### PR DESCRIPTION
When order selected, a wrong redirection to the order's card has been endorsed.
In order to fix this behavior, the selection of the order has been modified from filtered products into all products to give the selection the ability to find its match.