### PR TITLE
TASK-57402 : Fix Forbid buyer from editing order status to Paid only until the order is paid and the transaction has been fulfilled

### DIFF
--- a/perk-store-packaging/pom.xml
+++ b/perk-store-packaging/pom.xml
@@ -21,7 +21,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   <parent>
     <groupId>org.exoplatform.addons.perk-store</groupId>
     <artifactId>perk-store</artifactId>
-    <version>2.4.x-SNAPSHOT</version>
+    <version>2.4.x-meedsv2-SNAPSHOT</version>
   </parent>
   <artifactId>perk-store-packaging</artifactId>
   <packaging>pom</packaging>

--- a/perk-store-services/pom.xml
+++ b/perk-store-services/pom.xml
@@ -20,7 +20,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   <parent>
     <groupId>org.exoplatform.addons.perk-store</groupId>
     <artifactId>perk-store</artifactId>
-    <version>2.4.x-SNAPSHOT</version>
+    <version>2.4.x-meedsv2-SNAPSHOT</version>
   </parent>
   <artifactId>perk-store-services</artifactId>
   <name>eXo Add-on:: Perk Store - Services</name>

--- a/perk-store-webapps/pom.xml
+++ b/perk-store-webapps/pom.xml
@@ -20,7 +20,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   <parent>
     <groupId>org.exoplatform.addons.perk-store</groupId>
     <artifactId>perk-store</artifactId>
-    <version>2.4.x-SNAPSHOT</version>
+    <version>2.4.x-meedsv2-SNAPSHOT</version>
   </parent>
   <artifactId>perk-store-webapps</artifactId>
   <packaging>war</packaging>

--- a/perk-store-webapps/src/main/webapp/vue-app/components/perk-store/OrderDetail.vue
+++ b/perk-store-webapps/src/main/webapp/vue-app/components/perk-store/OrderDetail.vue
@@ -50,10 +50,11 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
                 class="small my-auto me-2 ignore-vuetify-classes"
                 @change="changeStatus()">
                 <option
-                  v-for="option in statusList"
+                  v-for="option in statusListItems"
                   :key="option"
-                  :value="option">
-                  {{ $t(`exoplatform.perkstore.label.status.${option.toLowerCase()}`) }}
+                  :value="option.name"
+                  :disabled="option.disabled">
+                  {{ $t(`exoplatform.perkstore.label.status.${option.name.toLowerCase()}`) }}
                 </option>
               </select>
             </template>
@@ -206,15 +207,35 @@ export default {
       // is finished
       refunding: false,
       orderProduct: {},
-      statusList: [
-        'ORDERED',
-        'CANCELED',
-        'ERROR',
-        'PAID',
-        'PARTIAL',
-        'DELIVERED',
-        'REFUNDED',
-        'FRAUD',
+      disableOptionSelection: this.order.status.toLowerCase() === 'ordered',
+      statusListItems: [
+        {
+          name: 'ORDERED',
+          disabled: this.disableOptionSelection
+        },
+        {
+          name: 'CANCELED'
+        },
+        {
+          name: 'ERROR'
+        },
+        {
+          name: 'PAID',
+          disabled: !this.disableOptionSelection
+        }
+        ,
+        {
+          name: 'PARTIAL',
+        },
+        {
+          name: 'DELIVERED',
+        },
+        {
+          name: 'REFUNDED',
+        },
+        {
+          name: 'FRAUD',
+        },
       ],
     };
   },
@@ -349,6 +370,11 @@ export default {
         this.$emit('error', e && e.message ? e.message : String(e));
       });
     },
+  },
+  watch: {
+    isItOrdered() {
+      return this.order.status === this.isOrdered ? true : false ; 
+    }
   }
 };
 </script>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   </parent>
   <groupId>org.exoplatform.addons.perk-store</groupId>
   <artifactId>perk-store</artifactId>
-  <version>2.4.x-SNAPSHOT</version>
+  <version>2.4.x-meedsv2-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>eXo Add-on:: Perk Store - Parent POM</name>
   <description>Perk Store Addon</description>
@@ -44,8 +44,8 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   </scm>
   <properties>
     <!-- 3rd party libraries versions -->
-    <org.exoplatform.social.version>6.4.x-SNAPSHOT</org.exoplatform.social.version>
-    <org.exoplatform.platform-ui.version>6.4.x-SNAPSHOT</org.exoplatform.platform-ui.version>
+    <org.exoplatform.social.version>6.4.x-meedsv2-SNAPSHOT</org.exoplatform.social.version>
+    <org.exoplatform.platform-ui.version>6.4.x-meedsv2-SNAPSHOT</org.exoplatform.platform-ui.version>
     
     <!-- Sonar properties -->
     <sonar.organization>meeds-io</sonar.organization>


### PR DESCRIPTION
When a product is ordered, the order's label turns to Ordered, but it has been found out that the product's owner is still able to change the order's status to PAID although the transaction has not been finalised.
to solve this behaviour, the selected "PAID" option has been controlled depending on the order's status, if the order is ordered qnd not payed yet, the option "PAID" is disabled  and so on and so forth .