### PR TITLE
TASK-57402: Fix Forbid buyer from editing order status to Paid only until the order is paid .

### DIFF
--- a/perk-store-webapps/src/main/webapp/vue-app/components/perk-store/OrderDetail.vue
+++ b/perk-store-webapps/src/main/webapp/vue-app/components/perk-store/OrderDetail.vue
@@ -50,10 +50,11 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
                 class="small my-auto me-2 ignore-vuetify-classes"
                 @change="changeStatus()">
                 <option
-                  v-for="option in statusList"
+                  v-for="option in statusListItems"
                   :key="option"
-                  :value="option">
-                  {{ $t(`exoplatform.perkstore.label.status.${option.toLowerCase()}`) }}
+                  :value="option.name"
+                  :disabled="option.disabled">
+                  {{ $t(`exoplatform.perkstore.label.status.${option.name.toLowerCase()}`) }}
                 </option>
               </select>
             </template>
@@ -206,15 +207,35 @@ export default {
       // is finished
       refunding: false,
       orderProduct: {},
-      statusList: [
-        'ORDERED',
-        'CANCELED',
-        'ERROR',
-        'PAID',
-        'PARTIAL',
-        'DELIVERED',
-        'REFUNDED',
-        'FRAUD',
+      disableOptionSelection: this.order.status.toLowerCase() === 'ordered',
+      statusListItems: [
+        {
+          name: 'ORDERED',
+          disabled: this.disableOptionSelection
+        },
+        {
+          name: 'CANCELED'
+        },
+        {
+          name: 'ERROR'
+        },
+        {
+          name: 'PAID',
+          disabled: !this.disableOptionSelection
+        }
+        ,
+        {
+          name: 'PARTIAL',
+        },
+        {
+          name: 'DELIVERED',
+        },
+        {
+          name: 'REFUNDED',
+        },
+        {
+          name: 'FRAUD',
+        },
       ],
     };
   },
@@ -349,6 +370,11 @@ export default {
         this.$emit('error', e && e.message ? e.message : String(e));
       });
     },
+  },
+  watch: {
+    isItOrdered() {
+      return this.order.status === this.isOrdered ? true : false ; 
+    }
   }
 };
 </script>

--- a/perk-store-webapps/src/main/webapp/vue-app/components/perk-store/OrderDetail.vue
+++ b/perk-store-webapps/src/main/webapp/vue-app/components/perk-store/OrderDetail.vue
@@ -207,11 +207,10 @@ export default {
       // is finished
       refunding: false,
       orderProduct: {},
-      disableOptionSelection: this.order.status.toLowerCase() === 'ordered',
       statusListItems: [
         {
           name: 'ORDERED',
-          disabled: this.disableOptionSelection
+          disabled: this.order.status.toLowerCase() !== 'ordered'
         },
         {
           name: 'CANCELED'
@@ -221,14 +220,15 @@ export default {
         },
         {
           name: 'PAID',
-          disabled: !this.disableOptionSelection
-        }
-        ,
+          disabled: this.order.status.toLowerCase() !== 'paid'
+        },
         {
           name: 'PARTIAL',
+          
         },
         {
           name: 'DELIVERED',
+          disabled: this.order.status.toLowerCase() !== 'delivered'
         },
         {
           name: 'REFUNDED',
@@ -371,10 +371,5 @@ export default {
       });
     },
   },
-  watch: {
-    isItOrdered() {
-      return this.order.status === this.isOrdered ? true : false ; 
-    }
-  }
 };
 </script>


### PR DESCRIPTION
When a product is ordered, the order's label turns to Ordered, but it has been found out that the product's owner is still able to change the order's status to PAID although the transaction has not been finalised.
to solve this behaviour, the selected "PAID" option has been controlled depending on the order's status, if the order is ordered qnd not payed yet, the option "PAID" is disabled and so on and so forth .