### PR TITLE
TASK-57588: Fix hands cursor when hovering on product's edit options

### DIFF
--- a/perk-store-webapps/src/main/webapp/vue-app/components/perk-store/ProductDetail.vue
+++ b/perk-store-webapps/src/main/webapp/vue-app/components/perk-store/ProductDetail.vue
@@ -62,17 +62,17 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
                     class="editLabelProduct"
                     @mousedown="$event.preventDefault()">
                     <v-list-item-title class="editProductMenu ml-n2" @click="$emit('edit', product)">
-                      <i class="uiIconEdit mr-2"> </i>{{ $t('exoplatform.perkstore.button.menuEditProduct') }}
+                      <i class="uiIconEdit" :class="iconClass"> </i>{{ $t('exoplatform.perkstore.button.menuEditProduct') }}
                     </v-list-item-title>
                   </v-list-item>
                   <v-list-item class="editLabelProduct" @mousedown="$event.preventDefault()">
                     <v-list-item-title class="editProductMenu ml-n2" @click="$emit('orders-list', product, null)">
-                      <i class="fas fa-list primary--text mr-2"> </i>{{ $t('exoplatform.perkstore.button.menuProductOrders') }}
+                      <i class="fas fa-list primary--text" :class="iconClass"> </i>{{ $t('exoplatform.perkstore.button.menuProductOrders') }}
                     </v-list-item-title>
                   </v-list-item>
                   <v-list-item class="editLabelProduct" @mousedown="$event.preventDefault()">
                     <v-list-item-title class="editProductMenu ml-n2" @click="confirmDelete()">
-                      <i class="uiIconTrash primary--text mr-2"> </i>{{ $t('exoplatform.perkstore.button.menuProductDelete') }}
+                      <i class="uiIconTrash primary--text" :class="iconClass"> </i>{{ $t('exoplatform.perkstore.button.menuProductDelete') }}
                     </v-list-item-title>
                   </v-list-item>
                 </v-list>
@@ -211,12 +211,8 @@ export default {
     },
   },
   data: () => ({
-    showMenu: false,
-    isItLeftSidedLanguage: false
+    showMenu: false
   }),
-  created() {
-    this.isItLeftSidedLanguage = this.$i18n.locale !== 'ar';
-  },
   computed: {
     isProductOwner() {
       return this.product.userData.canEdit || this.product.userData.username === this.product.creator.id || this.product.userData.username === this.product.receiverMarchand.id ;
@@ -306,6 +302,12 @@ export default {
         return available > 0 ? available : 0;
       }
     },
+    iconClass () {
+      return !this.$vuetify.rtl && 'mr-2 ' || 'ml-2';
+    },
+    isItLeftSidedLanguage() {
+      return !this.$vuetify.rtl; 
+    }
   },
   methods: {
     closeMenu() {

--- a/perk-store-webapps/src/main/webapp/vue-app/components/perk-store/ProductDetail.vue
+++ b/perk-store-webapps/src/main/webapp/vue-app/components/perk-store/ProductDetail.vue
@@ -62,17 +62,17 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
                     class="editLabelProduct"
                     @mousedown="$event.preventDefault()">
                     <v-list-item-title class="editProductMenu ml-n2" @click="$emit('edit', product)">
-                      <em class="uiIconEdit" :class="iconClass"> </em>{{ $t('exoplatform.perkstore.button.menuEditProduct') }}
+                      <i class="uiIconEdit" :class="iconClass"> </i>{{ $t('exoplatform.perkstore.button.menuEditProduct') }}
                     </v-list-item-title>
                   </v-list-item>
                   <v-list-item class="editLabelProduct" @mousedown="$event.preventDefault()">
                     <v-list-item-title class="editProductMenu ml-n2" @click="$emit('orders-list', product, null)">
-                      <em class="fas fa-list primary--text" :class="iconClass"> </em>{{ $t('exoplatform.perkstore.button.menuProductOrders') }}
+                      <i class="fas fa-list primary--text" :class="iconClass"> </i>{{ $t('exoplatform.perkstore.button.menuProductOrders') }}
                     </v-list-item-title>
                   </v-list-item>
                   <v-list-item class="editLabelProduct" @mousedown="$event.preventDefault()">
                     <v-list-item-title class="editProductMenu ml-n2" @click="confirmDelete()">
-                      <em class="uiIconTrash primary--text" :class="iconClass"> </em>{{ $t('exoplatform.perkstore.button.menuProductDelete') }}
+                      <i class="uiIconTrash primary--text" :class="iconClass"> </i>{{ $t('exoplatform.perkstore.button.menuProductDelete') }}
                     </v-list-item-title>
                   </v-list-item>
                 </v-list>

--- a/perk-store-webapps/src/main/webapp/vue-app/components/perk-store/ProductDetail.vue
+++ b/perk-store-webapps/src/main/webapp/vue-app/components/perk-store/ProductDetail.vue
@@ -43,9 +43,9 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
                 v-if="isProductOwner"
                 v-model="showMenu"
                 offset-x
-                min-width="220"
-                attach
-                auto>
+                offset-y
+                :left="isItLeftSidedLanguage"
+                attach>
                 <template #activator="{ on}">
                   <v-btn
                     dark
@@ -211,8 +211,12 @@ export default {
     },
   },
   data: () => ({
-    showMenu: false
+    showMenu: false,
+    isItLeftSidedLanguage: false
   }),
+  created() {
+    this.isItLeftSidedLanguage = this.$i18n.locale !== 'ar';
+  },
   computed: {
     isProductOwner() {
       return this.product.userData.canEdit || this.product.userData.username === this.product.creator.id || this.product.userData.username === this.product.receiverMarchand.id ;

--- a/perk-store-webapps/src/main/webapp/vue-app/components/perk-store/ProductDetail.vue
+++ b/perk-store-webapps/src/main/webapp/vue-app/components/perk-store/ProductDetail.vue
@@ -62,17 +62,17 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
                     class="editLabelProduct"
                     @mousedown="$event.preventDefault()">
                     <v-list-item-title class="editProductMenu ml-n2" @click="$emit('edit', product)">
-                      <i class="uiIconEdit" :class="iconClass"> </i>{{ $t('exoplatform.perkstore.button.menuEditProduct') }}
+                      <em class="uiIconEdit" :class="iconClass"> </em>{{ $t('exoplatform.perkstore.button.menuEditProduct') }}
                     </v-list-item-title>
                   </v-list-item>
                   <v-list-item class="editLabelProduct" @mousedown="$event.preventDefault()">
                     <v-list-item-title class="editProductMenu ml-n2" @click="$emit('orders-list', product, null)">
-                      <i class="fas fa-list primary--text" :class="iconClass"> </i>{{ $t('exoplatform.perkstore.button.menuProductOrders') }}
+                      <em class="fas fa-list primary--text" :class="iconClass"> </em>{{ $t('exoplatform.perkstore.button.menuProductOrders') }}
                     </v-list-item-title>
                   </v-list-item>
                   <v-list-item class="editLabelProduct" @mousedown="$event.preventDefault()">
                     <v-list-item-title class="editProductMenu ml-n2" @click="confirmDelete()">
-                      <i class="uiIconTrash primary--text" :class="iconClass"> </i>{{ $t('exoplatform.perkstore.button.menuProductDelete') }}
+                      <em class="uiIconTrash primary--text" :class="iconClass"> </em>{{ $t('exoplatform.perkstore.button.menuProductDelete') }}
                     </v-list-item-title>
                   </v-list-item>
                 </v-list>


### PR DESCRIPTION
when hovering on product's options when trying to edit it turns out that the hands cursor is not showing,
I turns out that the v-menu should be attached to the v-carrousel . so attach attribute has been added
and to avoid TASK-57079 bad UI when switching to arabic language ; v-select has been set to auto to be centred and a minimum width has been added .