### PR TITLE
TASK-57588: Fix hands cursor when hovering on product's edit options.

### DIFF
--- a/perk-store-webapps/src/main/webapp/vue-app/components/perk-store/ProductDetail.vue
+++ b/perk-store-webapps/src/main/webapp/vue-app/components/perk-store/ProductDetail.vue
@@ -44,7 +44,8 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
                 v-model="showMenu"
                 offset-x
                 offset-y
-                :nudge-left="95">
+                :left="rtlDisplay"
+                attach>
                 <template #activator="{ on}">
                   <v-btn
                     dark
@@ -61,17 +62,17 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
                     class="editLabelProduct"
                     @mousedown="$event.preventDefault()">
                     <v-list-item-title class="editProductMenu ml-n2" @click="$emit('edit', product)">
-                      <i class="uiIconEdit mr-2"> </i>{{ $t('exoplatform.perkstore.button.menuEditProduct') }}
+                      <i class="uiIconEdit" :class="iconClass"> </i>{{ $t('exoplatform.perkstore.button.menuEditProduct') }}
                     </v-list-item-title>
                   </v-list-item>
                   <v-list-item class="editLabelProduct" @mousedown="$event.preventDefault()">
                     <v-list-item-title class="editProductMenu ml-n2" @click="$emit('orders-list', product, null)">
-                      <i class="fas fa-list primary--text mr-2"> </i>{{ $t('exoplatform.perkstore.button.menuProductOrders') }}
+                      <i class="fas fa-list primary--text" :class="iconClass"> </i>{{ $t('exoplatform.perkstore.button.menuProductOrders') }}
                     </v-list-item-title>
                   </v-list-item>
                   <v-list-item class="editLabelProduct" @mousedown="$event.preventDefault()">
                     <v-list-item-title class="editProductMenu ml-n2" @click="confirmDelete()">
-                      <i class="uiIconTrash primary--text mr-2"> </i>{{ $t('exoplatform.perkstore.button.menuProductDelete') }}
+                      <i class="uiIconTrash primary--text" :class="iconClass"> </i>{{ $t('exoplatform.perkstore.button.menuProductDelete') }}
                     </v-list-item-title>
                   </v-list-item>
                 </v-list>
@@ -301,6 +302,12 @@ export default {
         return available > 0 ? available : 0;
       }
     },
+    iconClass () {
+      return !this.$vuetify.rtl && 'mr-2 ' || 'ml-2';
+    },
+    rtlDisplay() {
+      return !this.$vuetify.rtl; 
+    }
   },
   methods: {
     closeMenu() {


### PR DESCRIPTION
when hovering on product's options when trying to edit it turns out that the hands cursor is not showing,
I turns out that the v-menu should be attached to the v-carrousel . so attach attribute has been added
and to avoid TASK-57079 bad UI when switching to arabic language ; v-select has been set to auto to be centred and a minimum width has been added .