### PR TITLE
Task-55138: add jdenticon for metamask address in buy form drawer

### DIFF
--- a/perk-store-webapps/src/main/webapp/WEB-INF/gatein-resources.xml
+++ b/perk-store-webapps/src/main/webapp/WEB-INF/gatein-resources.xml
@@ -32,6 +32,10 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
         <path>/js/perkstore.bundle.js</path>
       </script>
       <depends>
+        <module>walletCommon</module>
+        <as>WalletCommon</as>
+      </depends>
+      <depends>
         <module>vue</module>
       </depends>
       <depends>

--- a/perk-store-webapps/src/main/webapp/vue-app/components/perk-store/BuyForm.vue
+++ b/perk-store-webapps/src/main/webapp/vue-app/components/perk-store/BuyForm.vue
@@ -137,6 +137,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
             <span class="mr-3 dark-grey-color walletTitle">
               {{ metamaskAddressPreview }}
             </span>
+            <wallet-settings-jdenticon :address="senderAddress" />
           </v-chip>
         </v-col>
         <v-text-field


### PR DESCRIPTION
When the drawer buy form is displayed, a jdenticon near the metamask address has been added ( only in case of connection to the metamask).