### PR TITLE
Task-46150: Case of changing the merchant wallet of a product

### DIFF
--- a/perk-store-webapps/src/main/webapp/vue-app/components/perk-store/ProductDetail.vue
+++ b/perk-store-webapps/src/main/webapp/vue-app/components/perk-store/ProductDetail.vue
@@ -229,7 +229,7 @@ export default {
     buyButtonTitle(){
       if (!this.walletEnabled || this.walletDeleted) {
         return this.$t('exoplatform.perkstore.label.disabledOrDeletedWallet');
-      }  else if ((this.product.creator.id === eXo.env.portal.userName) || (this.product.receiverMarchand.id === eXo.env.portal.userName)){
+      }  else if (this.product.receiverMarchand.id === eXo.env.portal.userName){
         return this.$t('exoplatform.perkstore.button.disabledBuyButton');
       } else if (!this.product.enabled){
         return  this.$t('exoplatform.perkstore.label.disabledProduct');
@@ -273,8 +273,7 @@ export default {
       return !this.hideButtons && this.product && this.product.enabled && this.userData.canOrder
           && this.product.receiverMarchand && this.product.receiverMarchand.type && this.product.receiverMarchand.id
           && (this.product.receiverMarchand.type !== 'user' || this.product.receiverMarchand.id !== eXo.env.portal.userName)
-          && this.product.creator && this.product.creator.type && this.product.creator.id
-          && (this.product.creator.type !== 'user' || this.product.creator.id !== eXo.env.portal.userName);
+          && this.product.creator && this.product.creator.type && this.product.creator.id;
     },
     disabledBuy() {
       return (!this.product.unlimited && this.available <= 0) || this.maxOrdersReached;


### PR DESCRIPTION
When a super user edits a product and changes the merchant wallet of a product initially created by a user, the purchase icon was enabled for the creator with "buy" tooltip and was disabled for the super user with tooltip " you can't buy your own product"