### PR TITLE
Task-57675: update the possibilty to manage orders and notification recipients.

### DIFF
--- a/perk-store-services/src/main/java/org/exoplatform/perkstore/service/utils/NotificationUtils.java
+++ b/perk-store-services/src/main/java/org/exoplatform/perkstore/service/utils/NotificationUtils.java
@@ -337,9 +337,10 @@ public class NotificationUtils {
 
       // Retain in recipient list only users who are member of both ACL
 
-      if(StringUtils.equals(product.getReceiverMarchand().getType(), "user")) {
+      if(StringUtils.equals(product.getReceiverMarchand().getType(), USER_ACCOUNT_TYPE)) {
         addIdentityMembersFromProfiles(Collections.singleton(product.getReceiverMarchand()), recipientList);
-      } else if (marchands != null && !marchands.isEmpty()) {
+      }
+      if (marchands != null && !marchands.isEmpty()) {
         addIdentityMembersFromProfiles(marchands, recipientList);
       }
       
@@ -351,9 +352,10 @@ public class NotificationUtils {
       // Always send to buyer
       recipientList.add(order.getSender().getId());
 
-      if(StringUtils.equals(product.getReceiverMarchand().getType(), "user")) {
+      if(StringUtils.equals(product.getReceiverMarchand().getType(), USER_ACCOUNT_TYPE)) {
         addIdentityMembersFromProfiles(Collections.singleton(product.getReceiverMarchand()), recipientList);
-      } else if (marchands != null && !marchands.isEmpty()) {
+      }
+      if (marchands != null && !marchands.isEmpty()) {
         addIdentityMembersFromProfiles(marchands, recipientList);
       }
 

--- a/perk-store-services/src/main/java/org/exoplatform/perkstore/service/utils/NotificationUtils.java
+++ b/perk-store-services/src/main/java/org/exoplatform/perkstore/service/utils/NotificationUtils.java
@@ -295,6 +295,7 @@ public class NotificationUtils {
                                                      Profile modifier) {
     Set<String> ignoredUsers = new HashSet<>();
     Set<String> recipientList = new HashSet<>();
+    List<Profile> marchands = product.getMarchands();
 
     if (order == null) {// New or modified product
       if (newProduct) {
@@ -335,7 +336,13 @@ public class NotificationUtils {
       ignoredUsers.add(order.getSender().getId());
 
       // Retain in recipient list only users who are member of both ACL
-      addIdentityMembersFromProfiles(product.getMarchands(), recipientList);
+
+      if(StringUtils.equals(product.getReceiverMarchand().getType(), "user")) {
+        addIdentityMembersFromProfiles(Collections.singleton(product.getReceiverMarchand()), recipientList);
+      } else if (marchands != null && !marchands.isEmpty()) {
+        addIdentityMembersFromProfiles(marchands, recipientList);
+      }
+      
     } else {// Modified order
       if (modifier != null) {
         ignoredUsers.add(modifier.getId());
@@ -344,7 +351,12 @@ public class NotificationUtils {
       // Always send to buyer
       recipientList.add(order.getSender().getId());
 
-      addIdentityMembersFromProfiles(product.getMarchands(), recipientList);
+      if(StringUtils.equals(product.getReceiverMarchand().getType(), "user")) {
+        addIdentityMembersFromProfiles(Collections.singleton(product.getReceiverMarchand()), recipientList);
+      } else if (marchands != null && !marchands.isEmpty()) {
+        addIdentityMembersFromProfiles(marchands, recipientList);
+      }
+
     }
 
     recipientList.removeAll(ignoredUsers);

--- a/perk-store-webapps/src/main/webapp/vue-app/components/perk-store/ProductDetail.vue
+++ b/perk-store-webapps/src/main/webapp/vue-app/components/perk-store/ProductDetail.vue
@@ -217,6 +217,9 @@ export default {
     isProductOwner() {
       return this.product.userData.canEdit || this.product.userData.username === this.product.creator.id || this.product.userData.username === this.product.receiverMarchand.id ;
     },
+    isProductMerchant() {
+      return this.product.receiverMarchand.type === 'user' ? (this.product.receiverMarchand.id === eXo.env.portal.userName) : this.product.marchands.find(marchand => marchand.id === eXo.env.portal.userName);
+    },
     cardTextClass() {
       return this.cantBuyProduct ? '' : 'clickable ';
     },


### PR DESCRIPTION
Prior to this change, when a product creator buys his product (in the case of a product whose merchant has been changed and his wallet has been deleted), notifications about the product purchase, have been sent to the new merchant wallet and the orders option has been removed from the creator's 3 dot icon. 
On the other part of the wallet of the new merchant, the user has the possibility to modify the product.


