### PR TITLE
TASK-52081 :fix send notification when adding new product

### DIFF
--- a/perk-store-services/pom.xml
+++ b/perk-store-services/pom.xml
@@ -93,6 +93,16 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
       <artifactId>hsqldb</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-api-mockito2</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-module-junit4</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <finalName>perk-store-services</finalName>

--- a/perk-store-services/src/main/java/org/exoplatform/perkstore/service/utils/NotificationUtils.java
+++ b/perk-store-services/src/main/java/org/exoplatform/perkstore/service/utils/NotificationUtils.java
@@ -330,6 +330,7 @@ public class NotificationUtils {
       } else {
         addIdentityMembersFromProfiles(product.getMarchands(), recipientList);
         addIdentityMembersFromProfiles(Collections.singleton(product.getReceiverMarchand()), recipientList);
+        recipientList.addAll(Utils.getRewardingGroupMember());
       }
     } else if (newOrder) {// New order
       ignoredUsers.add(order.getSender().getId());

--- a/perk-store-services/src/main/java/org/exoplatform/perkstore/service/utils/Utils.java
+++ b/perk-store-services/src/main/java/org/exoplatform/perkstore/service/utils/Utils.java
@@ -809,9 +809,11 @@ public class Utils {
       if (rewardingGroup != null) {
         ListAccess<Membership> rewardingMembers = getOrganizationService().getMembershipHandler()
                                                                           .findAllMembershipsByGroup(rewardingGroup);
-        Membership[] members = rewardingMembers.load(0, rewardingMembers.getSize());
-        for (Membership membership : members) {
-          groupMember.add(membership.getUserName());
+        if(rewardingMembers != null) {
+          Membership[] members = rewardingMembers.load(0, rewardingMembers.getSize());
+          for (Membership membership : members) {
+            groupMember.add(membership.getUserName());
+          }
         }
       }
       return groupMember;

--- a/perk-store-services/src/main/java/org/exoplatform/perkstore/service/utils/Utils.java
+++ b/perk-store-services/src/main/java/org/exoplatform/perkstore/service/utils/Utils.java
@@ -802,4 +802,22 @@ public class Utils {
     return imageIds;
   }
 
+  public static List<String> getRewardingGroupMember() {
+    List<String> groupMember = new ArrayList<>();
+    try {
+      Group rewardingGroup = getOrganizationService().getGroupHandler().findGroupById(REWARDING_GROUP);
+      if (rewardingGroup != null) {
+        ListAccess<Membership> rewardingMembers = getOrganizationService().getMembershipHandler()
+                                                                          .findAllMembershipsByGroup(rewardingGroup);
+        Membership[] members = rewardingMembers.load(0, rewardingMembers.getSize());
+        for (Membership membership : members) {
+          groupMember.add(membership.getUserName());
+        }
+      }
+      return groupMember;
+    } catch (Exception e) {
+      LOG.error("Error while getting group member", e);
+      return Collections.emptyList();
+    }
+  }
 }

--- a/perk-store-services/src/test/java/org/exoplatform/perkstore/test/service/utils/NotificationUtilsTest.java
+++ b/perk-store-services/src/test/java/org/exoplatform/perkstore/test/service/utils/NotificationUtilsTest.java
@@ -1,0 +1,65 @@
+package org.exoplatform.perkstore.test.service.utils;
+
+import org.exoplatform.commons.api.notification.NotificationContext;
+import org.exoplatform.commons.api.notification.model.NotificationInfo;
+import org.exoplatform.commons.notification.impl.NotificationContextImpl;
+import org.exoplatform.container.xml.InitParams;
+import org.exoplatform.perkstore.model.GlobalSettings;
+import org.exoplatform.perkstore.model.Product;
+import org.exoplatform.perkstore.model.Profile;
+import org.exoplatform.perkstore.model.constant.ProductOrderModificationType;
+import org.exoplatform.perkstore.notification.plugin.PerkStoreNotificationPlugin;
+import org.exoplatform.perkstore.service.utils.NotificationUtils;
+import org.exoplatform.perkstore.service.utils.Utils;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.exoplatform.perkstore.service.utils.NotificationUtils.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(PowerMockRunner.class)
+@PowerMockIgnore({ "javax.management.*", "javax.xml.*", "org.xml.*" })
+public class NotificationUtilsTest {
+
+  @PrepareForTest({ Utils.class, NotificationInfo.class })
+
+  @Test
+  public void testSetNotificationRecipients() {
+    PowerMockito.mockStatic(Utils.class);
+    PowerMockito.mockStatic(NotificationInfo.class);
+    List<String> groupMember = new ArrayList<>();
+    groupMember.add("user");
+    groupMember.add("user1");
+    groupMember.add("user2");
+    groupMember.add("user3");
+
+    when(Utils.getRewardingGroupMember()).thenReturn(groupMember);
+    try {
+      GlobalSettings globalSettings = new GlobalSettings();
+      Profile userProfile = new Profile(1L);
+      Product product = new Product();
+      userProfile.setId("user");
+      product.setReceiverMarchand(userProfile);
+      product.setMarchands(Arrays.asList(userProfile));
+      product.setCreator(userProfile);
+      NotificationInfo notification = new NotificationInfo();
+      NotificationUtils.setNotificationRecipients(notification, globalSettings, product, null, true, false, userProfile);
+
+      // should be just 3 since one of the group member is the creator
+      assertNotNull(notification.getSendToUserIds());
+      assertEquals(3, notification.getSendToUserIds().size());
+    } catch (Exception e) {
+    }
+  }
+}

--- a/perk-store-services/src/test/java/org/exoplatform/perkstore/test/service/utils/UtilsTest.java
+++ b/perk-store-services/src/test/java/org/exoplatform/perkstore/test/service/utils/UtilsTest.java
@@ -1,0 +1,83 @@
+package org.exoplatform.perkstore.test.service.utils;
+
+import org.exoplatform.commons.utils.CommonsUtils;
+import org.exoplatform.commons.utils.ListAccess;
+import org.exoplatform.commons.utils.ListAccessImpl;
+import org.exoplatform.perkstore.service.utils.Utils;
+import org.exoplatform.perkstore.test.BasePerkStoreTest;
+import org.exoplatform.services.organization.GroupHandler;
+import org.exoplatform.services.organization.Membership;
+import org.exoplatform.services.organization.MembershipHandler;
+import org.exoplatform.services.organization.OrganizationService;
+import org.exoplatform.services.organization.impl.GroupImpl;
+import org.exoplatform.services.organization.impl.MembershipImpl;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.exoplatform.perkstore.service.utils.Utils.REWARDING_GROUP;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(PowerMockRunner.class)
+@PowerMockIgnore({"javax.management.*", "javax.xml.*", "org.xml.*"})
+public class UtilsTest {
+
+  @PrepareForTest(CommonsUtils.class)
+  @Test
+  public void testGetRewardingGroupMember() {
+    PowerMockito.mockStatic(CommonsUtils.class);
+    OrganizationService organizationService = mock(OrganizationService.class);
+    when(CommonsUtils.getService(OrganizationService.class)).thenReturn(organizationService);
+    GroupHandler groupHandler = mock(GroupHandler.class);
+    MembershipHandler membershipHandler = mock(MembershipHandler.class);
+    when(organizationService.getMembershipHandler()).thenReturn(membershipHandler);
+    when(organizationService.getGroupHandler()).thenReturn(groupHandler);
+
+    try {
+      GroupImpl group = new GroupImpl();
+      group.setId(Utils.REWARDING_GROUP);
+      List<String> groupMember = new ArrayList<>();
+      when(groupHandler.findGroupById(REWARDING_GROUP)).thenReturn(group);
+      when(membershipHandler.findAllMembershipsByGroup(group)).thenReturn(new ListAccessImpl(Membership.class, Collections.emptyList()));
+      groupMember = Utils.getRewardingGroupMember();
+      assertNotNull(groupMember);
+      assertEquals(0, groupMember.size());
+
+      List<Membership> memberships = new ArrayList<Membership>();
+
+      MembershipImpl member1 = new MembershipImpl();
+      member1.setMembershipType("member");
+      member1.setUserName("user1");
+      member1.setGroupId(REWARDING_GROUP);
+      memberships.add(member1);
+      MembershipImpl member2 = new MembershipImpl();
+      member2.setMembershipType("*");
+      member2.setUserName("user2");
+      member2.setGroupId(REWARDING_GROUP);
+      memberships.add(member2);
+
+      MembershipImpl member3 = new MembershipImpl();
+      member3.setMembershipType("*");
+      member3.setUserName("user3");
+      member3.setGroupId(REWARDING_GROUP);
+      memberships.add(member3);
+
+      ListAccess<Membership> membersShipList = new ListAccessImpl(Membership.class, memberships);
+      when(membershipHandler.findAllMembershipsByGroup(group)).thenReturn(membersShipList);
+
+      groupMember = Utils.getRewardingGroupMember();
+      assertNotNull(groupMember);
+      assertEquals(3, groupMember.size());
+    } catch (Exception e) {
+    }
+  }
+}


### PR DESCRIPTION
when no access permission is set into perkSstore administration no one receives a notification when adding a new product
fixed by sending a notification for the rewarding group member when no access permession is set