### PR TITLE
TASK-57825 : fix displaying product merchand and order receiver when their type is space 

### DIFF
--- a/perk-store-webapps/src/main/webapp/vue-app/components/PerkStoreApp.vue
+++ b/perk-store-webapps/src/main/webapp/vue-app/components/PerkStoreApp.vue
@@ -178,7 +178,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
                   </div>
                   <div v-else>
                     <span class="textBalance titleOrders">
-                       {{ $t('exoplatform.perkstore.label.balance') }} :
+                      {{ $t('exoplatform.perkstore.label.balance') }} :
                       <span class="symbol"> {{ symbol }} </span>
                       <span class="balance">{{ balance }}  </span>
                     </span>

--- a/perk-store-webapps/src/main/webapp/vue-app/components/perk-store/BuyForm.vue
+++ b/perk-store-webapps/src/main/webapp/vue-app/components/perk-store/BuyForm.vue
@@ -63,8 +63,16 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
           </v-row>
           <v-row v-if="product && product.receiverMarchand" class="pb-3">
             <exo-user-avatar
+              v-if="product.receiverMarchand.type === 'user'"
               :key="product.receiverMarchand.id"
               :profile-id="product.receiverMarchand.id"
+              :size="25"
+              extra-class="buyFormMarchant"
+              popover />
+            <exo-space-avatar
+              v-if="product.receiverMarchand.type === 'space'"
+              :key="product.receiverMarchand.id"
+              :space-id="product.receiverMarchand.spaceId"
               :size="25"
               extra-class="buyFormMarchant"
               popover />

--- a/perk-store-webapps/src/main/webapp/vue-app/components/perk-store/OrderDetail.vue
+++ b/perk-store-webapps/src/main/webapp/vue-app/components/perk-store/OrderDetail.vue
@@ -96,8 +96,15 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
             </template>
             <span class="px-1">{{ $t('exoplatform.perkstore.label.sentTo') }}</span>
             <exo-user-avatar
-              v-if="order.receiver"
+              v-if="order.receiver && order.receiver.type === 'user'"
               :profile-id="order.receiver.id"
+              :size="28"
+              fullname
+              link-style
+              popover />
+            <exo-space-avatar
+              v-if="order.receiver && order.receiver.type === 'space'"
+              :space-id="order.receiver.spaceId"
               :size="28"
               fullname
               link-style


### PR DESCRIPTION
prior to this change:  displaying product merchant or order receiver uses  exo-user-avatar component for both types user and space 
This change will allow  displaying space with exo-space-avatar and users in exo-user-avatar