### PR TITLE
BUILDERS-200: Manage network and account error cases .

### DIFF
--- a/perk-store-webapps/src/main/webapp/css/main.less
+++ b/perk-store-webapps/src/main/webapp/css/main.less
@@ -1421,9 +1421,15 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 
    @media (max-width: 599px) {
-    #perkstoreOrderPortlet {
-      .big-number {
-        margin-top: 0;
-      }
-    }
+        #perkstoreOrderPortlet {
+          .big-number {
+            margin-top: 0;
+          }
+        }
   }
+
+#perkStoreAlert {
+  .v-icon {
+    align-self: center !important;
+  }
+}

--- a/perk-store-webapps/src/main/webapp/vue-app/components/perk-store/perkStroreAlert.vue
+++ b/perk-store-webapps/src/main/webapp/vue-app/components/perk-store/perkStroreAlert.vue
@@ -1,10 +1,11 @@
 <template>
-  <v-alert
+  <v-alert 
+    id="perkStoreAlert"
     v-model="displayAlert"
     :type="alertType"
     dismissible
     :icon="alertType === 'warning' ? 'mdi-alert-circle' : ''">
-    <span v-sanitized-html="alertMessage"> </span>
+    <span v-sanitized-html="alertMessage" class="self-align-center"></span>
   </v-alert>
 </template>
 <script>
@@ -19,7 +20,7 @@ export default {
       this.alertMessage = alert.message;
       this.alertType = alert.type;
       this.displayAlert= true;
-      window.setTimeout(() => this.displayAlert = false, 5000);
+      //window.setTimeout(() => this.displayAlert = false, 5000);
     });
   }
 };


### PR DESCRIPTION
when `switching` to `metamask` a `misaligned` text has been detected, and when trying to `buy a product from the perk`'s store another  `misalignement` has been endorsed in the `warning` (`icon's misalignment`) . 
so in order to resolve this issue a `CSS` class has been added to align elements .