### PR TITLE
MEED-345 Fix perk store order refunding

### DIFF
--- a/perk-store-webapps/src/main/webapp/vue-app/components/perk-store/RefundDrawer.vue
+++ b/perk-store-webapps/src/main/webapp/vue-app/components/perk-store/RefundDrawer.vue
@@ -271,7 +271,7 @@ export default {
               'success', 
               this.$t('exoplatform.wallet.metamask.message.transactionSent'),
               this.order.transactionHash
-            ), console.log('order',this.order))
+            ))
           .catch(e => {
             console.error('Error saving refund order', e);
             this.loading = false;


### PR DESCRIPTION
this `change` is going to make it possible to `refund` user who used their `usernames` to `login` instead of `metamask` accounts and make it possible to `follow` the `transaction` when the `internal` `wallet` is used to `refund` .