### PR TITLE
feat: stabilize perk-store with jdk 17- EXO-60521

### DIFF
--- a/perk-store-services/pom.xml
+++ b/perk-store-services/pom.xml
@@ -135,7 +135,6 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
       <plugin>
         <groupId>org.projectlombok</groupId>
         <artifactId>lombok-maven-plugin</artifactId>
-        <version>1.18.0.0</version>
         <executions>
           <execution>
             <phase>generate-sources</phase>


### PR DESCRIPTION
remove unneeded Lombok  plugin version