### PR TITLE
feat: Add walletAPi portlet in perkstore dynamic container - EXO-60319

### DIFF
--- a/perk-store-webapps/src/main/webapp/WEB-INF/conf/perk-store/dynamic-container-configuration.xml
+++ b/perk-store-webapps/src/main/webapp/WEB-INF/conf/perk-store/dynamic-container-configuration.xml
@@ -27,6 +27,53 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
       <init-params>
         <value-param>
           <name>priority</name>
+          <value>5</value>
+        </value-param>
+        <value-param>
+          <name>containerName</name>
+          <value>bottom-perk-store-container</value>
+        </value-param>
+        <object-param>
+          <name>wallet-api-portlet</name>
+          <description></description>
+          <object type="org.exoplatform.commons.addons.PortletModel">
+            <field name="contentId">
+              <string>wallet/WalletAPI</string>
+            </field>
+            <field name="permissions">
+              <collection type="java.util.ArrayList">
+                <value>
+                  <string>*:/platform/users</string>
+                </value>
+                <value>
+                  <string>*:/platform/externals</string>
+                </value>
+              </collection>
+            </field>
+            <field name="title">
+              <string>>Wallet api Portlet</string>
+            </field>
+            <field name="showInfoBar">
+              <boolean>false</boolean>
+            </field>
+            <field name="showApplicationState">
+              <boolean>false</boolean>
+            </field>
+            <field name="showApplicationMode">
+              <boolean>false</boolean>
+            </field>
+          </object>
+        </object-param>
+      </init-params>
+    </component-plugin>
+    <component-plugin>
+      <name>addPlugin</name>
+      <set-method>addPlugin</set-method>
+      <type>org.exoplatform.commons.addons.AddOnPluginImpl</type>
+      <description></description>
+      <init-params>
+        <value-param>
+          <name>priority</name>
           <value>1</value>
         </value-param>
         <value-param>


### PR DESCRIPTION
Prior to this change, perkstore transactions and enablment are done through the wallet api and needed to be loaded in the perkstore page. This PR ensures to add the wallet api in perkstore container to allow it manage communication, between wallet and perkstore.
