### PR TITLE
feat: Overview page disable buy button - MEED-1481 - Meeds-io/MIPs#10

### DIFF
--- a/perk-store-services/src/main/resources/locale/addon/PerkStore_en.properties
+++ b/perk-store-services/src/main/resources/locale/addon/PerkStore_en.properties
@@ -269,7 +269,7 @@ exoplatform.perkstore.button.myOrders=My orders
 exoplatform.perkstore.button.addProduct=Add Product
 exoplatform.perkstore.button.settings=Settings
 exoplatform.perkstore.button.productInfo=Open product info
-exoplatform.perkstore.button.disabledBuyButton=You can't buy your own product
+exoplatform.perkstore.button.disabledBuyButton=You are the merchant, you cannot buy it
 exoplatform.perkstore.img.alt=Avatar of {0}
 
 search.connector.label.products=Products

--- a/perk-store-webapps/src/main/webapp/vue-app/components/perk-store/BuyModal.vue
+++ b/perk-store-webapps/src/main/webapp/vue-app/components/perk-store/BuyModal.vue
@@ -136,13 +136,13 @@ export default {
     isMetamaskWallet() {
       return window.walletSettings.wallet?.provider === 'METAMASK';
     },
-    isProductOwner() {
-      return this.product.userData.canEdit || this.product.userData.username === this.product.creator.id || this.product.userData.username === this.product.receiverMarchand.id ;
+    canBuyProduct() {
+      return this.product?.receiverMarchand?.id && this.product?.userData?.username !== this.product.receiverMarchand.id;
     },
     buyButtonTitle(){
       if (!this.walletEnabled || this.walletDeleted) {
         return this.$t('exoplatform.perkstore.label.disabledOrDeletedWallet');
-      }  else if (this.product.receiverMarchand.id === eXo.env.portal.userName){
+      }  else if (this.product?.receiverMarchand?.id === this.product?.userData?.username){
         return this.$t('exoplatform.perkstore.button.disabledBuyButton');
       } else if (!this.product.enabled){
         return  this.$t('exoplatform.perkstore.label.disabledProduct');
@@ -153,7 +153,7 @@ export default {
       }
     },
     disabledButton () {
-      return (this.disableButton && (!this.isSameNetworkVersion || !this.isSameAddress)) || this.openedTransaction || this.isProductOwner ;
+      return (this.disableButton && (!this.isSameNetworkVersion || !this.isSameAddress)) || this.openedTransaction || !this.canBuyProduct ;
     }
   },
   created() {


### PR DESCRIPTION
this change is going to disable the buy button when clicking on the product in overview page perk store portlet knowing that the product merchant wallet is the same for the current user