### PR TITLE
fix: wrong column type for Product.isdeleted in postgresql - Meeds-io/meeds#791 - EXO-63088

### DIFF
--- a/perk-store-services/src/main/resources/db/changelog/perkstore-rdbms.db.changelog-1.0.0.xml
+++ b/perk-store-services/src/main/resources/db/changelog/perkstore-rdbms.db.changelog-1.0.0.xml
@@ -179,4 +179,12 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
       </column>
     </addColumn>
   </changeSet>
+
+  <changeSet author="perkstore" id="1.0.0-11">
+    <sql dbms="postgresql" >
+      ALTER TABLE ADDONS_PERKSTORE_PRODUCT ALTER COLUMN DELETED DROP DEFAULT;
+      ALTER TABLE ADDONS_PERKSTORE_PRODUCT ALTER DELETED TYPE bool USING DELETED::boolean;
+      ALTER TABLE ADDONS_PERKSTORE_PRODUCT ALTER COLUMN DELETED SET DEFAULT FALSE;
+    </sql>
+  </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
Using Postgresql database, the property Product.isDeleted was of type Int which is OK for Mysql but won't work with Postgresql leading to errors when creating products or displaying perkstore widget.
The fix corrects the type of the colum to Bool and migrates existing data