### PR TITLE
feat: Enable Push notifications Channel when addon installed - MEED-2062 - Meeds-io/meeds#900

### DIFF
--- a/perk-store-webapps/src/main/webapp/WEB-INF/conf/perk-store/notification-configuration.xml
+++ b/perk-store-webapps/src/main/webapp/WEB-INF/conf/perk-store/notification-configuration.xml
@@ -277,7 +277,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
         </value-param>
       </init-params>
     </component-plugin>
-    <component-plugin>
+    <component-plugin profiles="push-notifications">
       <name>push.channel.perkstore.template</name>
       <set-method>registerTemplateProvider</set-method>
       <type>org.exoplatform.perkstore.notification.provider.MobilePushTemplateProvider</type>


### PR DESCRIPTION
Prior to this change, Push notification channel was configured even when the addon isn't installed. This change will add this configuration only when push-notifications addon is added.