### PR TITLE
feat: Add Notification Administration Label - MEED-2445 - Meeds-io/MIPs#79

### DIFF
--- a/perk-store-webapps/src/main/resources/locale/portlet/NotificationAdministration_en.properties
+++ b/perk-store-webapps/src/main/resources/locale/portlet/NotificationAdministration_en.properties
@@ -1,0 +1,4 @@
+NotificationAdmin.ProductAddedNotificationPlugin=A product is added on store
+NotificationAdmin.OrderModifiedNotificationPlugin=A product order has been changed
+NotificationAdmin.ProductModifiedNotificationPlugin=A product is modified
+NotificationAdmin.OrderAddedNotificationPlugin=A product has been purchased

--- a/perk-store-webapps/src/main/resources/locale/portlet/NotificationAdministration_fr.properties
+++ b/perk-store-webapps/src/main/resources/locale/portlet/NotificationAdministration_fr.properties
@@ -1,0 +1,4 @@
+NotificationAdmin.ProductAddedNotificationPlugin=Un produit est ajout\u00E9 dans la boutique
+NotificationAdmin.OrderModifiedNotificationPlugin=Une commande a \u00E9t\u00E9 modifi\u00E9e
+NotificationAdmin.ProductModifiedNotificationPlugin=Un produit est modifi\u00E9
+NotificationAdmin.OrderAddedNotificationPlugin=Un produit est achet\u00E9

--- a/translations.properties
+++ b/translations.properties
@@ -24,3 +24,5 @@ portlet/PerkStore.properties=perk-store-services/src/main/resources/locale/addon
 portlet/Rewarding.properties=perk-store-services/src/main/resources/locale/navigation/group/platform/rewarding_en.properties
 portlet/PerkStoreError.properties=perk-store-services/src/main/resources/locale/addon/PerkStoreError_en.properties
 notification/PerkStoreNotification.properties=perk-store-services/src/main/resources/locale/notification/PerkStoreNotification_en.properties
+notification/NotificationAdministration.properties=perk-store-webapps/src/main/resources/locale/portlet/NotificationAdministration_en.properties
+


### PR DESCRIPTION
Prior to this change, the notification label is displayed the same way in administration and user settings. This change will add a dedicated label when in administration scope.