### PR TITLE
feat:  Apply Generic UI to existing portlet perkstore - MEED-2657 - Meeds-io/MIPs#81

### DIFF
--- a/perk-store-webapps/src/main/webapp/vue-app/components/PerkStoreApp.vue
+++ b/perk-store-webapps/src/main/webapp/vue-app/components/PerkStoreApp.vue
@@ -35,12 +35,13 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
         <div class="application-toolbar">
           <v-tabs
             v-model="tab"
-            slider-size="4">
+            slider-size="4"
+            class="card-border-radius overflow-hidden">
             <v-tab @click="refreshProductList">{{ $t('exoplatform.perkstore.label.Catalogue') }}</v-tab>
             <v-tab @click="displayMyOrdersList">{{ $t('exoplatform.perkstore.label.MyOrders') }}</v-tab>
           </v-tabs>
-          <v-tabs-items v-model="tab" class="tabs-content">
-            <v-tab-item class="product-list pa-4" eager>
+          <v-tabs-items v-model="tab" class="tabs-content card-border-radius">
+            <v-tab-item class="product-list pa-4 card-border-radius" eager>
               <perk-store-toolbar 
                 :can-add-product="userSettings.canAddProduct"
                 :symbol="symbol"
@@ -112,7 +113,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
                 info-message="exoplatform.perkstore.info.rewardsPerkstoreNoProductsDynamicPlaceholder" 
                 @no-result-event="isCatalogDisplayed && newProduct()" />
             </v-tab-item>
-            <v-tab-item class="orders-list pa-4" eager>
+            <v-tab-item class="orders-list card-border-radius pa-4" eager>
               <perk-store-toolbar 
                 :can-add-product="userSettings.canAddProduct"
                 :symbol="symbol"


### PR DESCRIPTION
This changes is about adding the new brandable border radius to the perkstore overview widget.