### PR TITLE
fix: Fix display of Placeholder in Perks Overview Widget - MEED-2919 - Meeds-io/MIPs#104

### DIFF
--- a/perk-store-webapps/src/main/webapp/vue-app/perk-store-overview/components/PerkStoreOverview.vue
+++ b/perk-store-webapps/src/main/webapp/vue-app/perk-store-overview/components/PerkStoreOverview.vue
@@ -78,13 +78,6 @@ export default {
       return this.wallet?.initializationState === 'DELETED';
     },
   },
-  watch: {
-    hasProducts() {
-      if (this.hasProducts) {
-        document.dispatchEvent(new CustomEvent('perk-store-products-loaded'));
-      }
-    },
-  },
   created() {
     this.init();
   },


### PR DESCRIPTION
Prior to this change, when having products in perk store, the overview widget of perks displays the placeholder in addition to the list of products. This change will delete a listener that will trigger an event without parameters which isn't intended to happen only after checking the list of available products.