### PR TITLE
fix: Fix referencing mandatory Wallet JS resources - MEED-3024 - Meeds-io/meeds#1351

### DIFF
--- a/perk-store-webapps/src/main/webapp/vue-app/perk-store.js
+++ b/perk-store-webapps/src/main/webapp/vue-app/perk-store.js
@@ -24,6 +24,8 @@ const vuetify = new Vuetify(eXo.env.portal.vuetifyPreset);
 const lang = (eXo && eXo.env && eXo.env.portal && eXo.env.portal.language) || 'en';
 const url = `${eXo.env.portal.context}/${eXo.env.portal.rest}/i18n/bundle/locale.addon.PerkStore-${lang}.json`;
 
+window.require(['PORTLET/wallet/WalletAPI']);
+
 export function init() {
   exoi18n.loadLanguageAsync(lang, url).then(i18n => {
     Vue.createApp({


### PR DESCRIPTION
Prior to this change, when adding PerkStore application, after deleting WalletAPI from sharedlayout dynamic container, the application has to add another portlet to be able to work (`wallet/WalletAPI`). This change will add this direct requirement in application startup phase (not in `gatein-resources.xml`) to not failt to start when the wallet addon is deleted but not perk-store.