### PR TITLE
fix: Delete useless Mocked methods - MEED-1580 - Meeds-io/meeds#1428

### DIFF
--- a/perk-store-services/src/test/java/org/exoplatform/perkstore/test/mock/IdentityManagerMock.java
+++ b/perk-store-services/src/test/java/org/exoplatform/perkstore/test/mock/IdentityManagerMock.java
@@ -65,7 +65,6 @@ public class IdentityManagerMock implements IdentityManager {
     }
   }
 
-  @Override
   public Identity getOrCreateIdentity(String providerId, String remoteId, boolean isProfileLoaded) {
     return identities.stream()
                      .filter(identity -> StringUtils.equals(identity.getProviderId(), providerId)
@@ -74,7 +73,6 @@ public class IdentityManagerMock implements IdentityManager {
                      .orElse(null);
   }
 
-  @Override
   public Identity getIdentity(String identityId, boolean isProfileLoaded) {
     return identities.stream()
                      .filter(identity -> StringUtils.equals(identity.getId(), identityId))
@@ -82,94 +80,76 @@ public class IdentityManagerMock implements IdentityManager {
                      .orElse(null);
   }
 
-  @Override
   public void registerIdentityProviders(IdentityProviderPlugin plugin) {
     // NOOP
   }
 
-  @Override
   public void addProfileListener(ProfileListenerPlugin plugin) {
     // NOOP
   }
 
-  @Override
   public Identity getIdentity(String providerId, String remoteId, boolean loadProfile) {
     return getOrCreateIdentity(providerId, remoteId, loadProfile);
   }
 
-  @Override
   public boolean identityExisted(String providerId, String remoteId) {
     return getOrCreateIdentity(providerId, remoteId, true) != null;
   }
 
-  @Override
   public Identity getIdentity(String id) {
     return getIdentity(id, true);
   }
 
-  @Override
   public Identity getOrCreateIdentity(String providerId, String remoteId) {
     return getOrCreateIdentity(providerId, remoteId, true);
   }
 
-  @Override
   public Identity updateIdentity(Identity identity) {
     return identity;
   }
 
-  @Override
   public List<Identity> getLastIdentities(int limit) {
     throw new UnsupportedOperationException();
   }
 
-  @Override
   public void deleteIdentity(Identity identity) {
     throw new UnsupportedOperationException();
   }
 
-  @Override
   public void hardDeleteIdentity(Identity identity) {
     throw new UnsupportedOperationException();
   }
 
-  @Override
   public ListAccess<Identity> getConnectionsWithListAccess(Identity identity) {
     throw new UnsupportedOperationException();
   }
 
-  @Override
   public Profile getProfile(Identity identity) {
     return identity.getProfile();
   }
 
-  @Override
   public InputStream getAvatarInputStream(Identity identity) throws IOException {
     throw new UnsupportedOperationException();
   }
 
-  @Override
   public InputStream getBannerInputStream(Identity identity) throws IOException {
     throw new UnsupportedOperationException();
   }
 
-  @Override
   public void updateProfile(Profile specificProfile) {
     // empty
   }
 
-  @Override
   public ListAccess<Identity> getIdentitiesByProfileFilter(String providerId,
                                                            ProfileFilter profileFilter,
                                                            boolean isProfileLoaded) {
     throw new UnsupportedOperationException();
   }
 
-  @Override
   public ListAccess<Identity> getIdentitiesForUnifiedSearch(String providerId, ProfileFilter profileFilter) {
     throw new UnsupportedOperationException();
   }
 
-  @Override
   public ListAccess<Identity> getSpaceIdentityByProfileFilter(Space space,
                                                               ProfileFilter profileFilter,
                                                               Type type,
@@ -177,32 +157,26 @@ public class IdentityManagerMock implements IdentityManager {
     throw new UnsupportedOperationException();
   }
 
-  @Override
   public void addIdentityProvider(IdentityProvider<?> identityProvider) {
     throw new UnsupportedOperationException();
   }
 
-  @Override
   public void removeIdentityProvider(IdentityProvider<?> identityProvider) {
     throw new UnsupportedOperationException();
   }
 
-  @Override
   public void registerProfileListener(ProfileListenerPlugin profileListenerPlugin) {
     throw new UnsupportedOperationException();
   }
 
-  @Override
   public void processEnabledIdentity(String remoteId, boolean isEnable) {
     throw new UnsupportedOperationException();
   }
 
-  @Override
   public List<Identity> getIdentitiesByProfileFilter(String providerId, ProfileFilter profileFilter) throws Exception {
     throw new UnsupportedOperationException();
   }
 
-  @Override
   public List<Identity> getIdentitiesByProfileFilter(String providerId,
                                                      ProfileFilter profileFilter,
                                                      long offset,
@@ -210,22 +184,18 @@ public class IdentityManagerMock implements IdentityManager {
     throw new UnsupportedOperationException();
   }
 
-  @Override
   public List<Identity> getIdentitiesByProfileFilter(ProfileFilter profileFilter) throws Exception {
     throw new UnsupportedOperationException();
   }
 
-  @Override
   public List<Identity> getIdentitiesByProfileFilter(ProfileFilter profileFilter, long offset, long limit) throws Exception {
     throw new UnsupportedOperationException();
   }
 
-  @Override
   public List<Identity> getIdentitiesFilterByAlphaBet(String providerId, ProfileFilter profileFilter) throws Exception {
     throw new UnsupportedOperationException();
   }
 
-  @Override
   public List<Identity> getIdentitiesFilterByAlphaBet(String providerId,
                                                       ProfileFilter profileFilter,
                                                       long offset,
@@ -233,93 +203,31 @@ public class IdentityManagerMock implements IdentityManager {
     throw new UnsupportedOperationException();
   }
 
-  @Override
   public List<Identity> getIdentitiesFilterByAlphaBet(ProfileFilter profileFilter) throws Exception {
     throw new UnsupportedOperationException();
   }
 
-  @Override
   public long getIdentitiesCount(String providerId) {
     throw new UnsupportedOperationException();
   }
 
-  @Override
-  public void saveIdentity(Identity identity) {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
-  public void saveProfile(Profile profile) {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
-  public void addOrModifyProfileProperties(Profile profile) throws Exception {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
-  public void updateAvatar(Profile p) {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
-  public void updateBasicInfo(Profile p) throws Exception {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
-  public void updateContactSection(Profile p) throws Exception {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
-  public void updateExperienceSection(Profile p) throws Exception {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
-  public void updateHeaderSection(Profile p) throws Exception {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
-  public List<Identity> getIdentities(String providerId) throws Exception {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
-  public List<Identity> getIdentities(String providerId, boolean loadProfile) throws Exception {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
   public List<Identity> getConnections(Identity ownerIdentity) throws Exception {
     throw new UnsupportedOperationException();
   }
 
-  @Override
   public IdentityStorage getIdentityStorage() {
     throw new UnsupportedOperationException();
   }
 
-  @Override
   public IdentityStorage getStorage() {
     throw new UnsupportedOperationException();
   }
 
-  @Override
   public void registerProfileListener(ProfileListener listener) {
     throw new UnsupportedOperationException();
   }
 
-  @Override
   public void unregisterProfileListener(ProfileListener listener) {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
-  public List<String> sortIdentities(List<String> identityRemoteIds, String sortField) {
     throw new UnsupportedOperationException();
   }
 

--- a/perk-store-services/src/test/java/org/exoplatform/perkstore/test/mock/SpaceServiceMock.java
+++ b/perk-store-services/src/test/java/org/exoplatform/perkstore/test/mock/SpaceServiceMock.java
@@ -574,16 +574,4 @@ public class SpaceServiceMock implements SpaceService {
     return false;
   }
 
-  public List<MembershipEntry> getSuperManagersMemberships() {
-    throw new UnsupportedOperationException();
-  }
-
-  public void addSuperManagersMembership(String permissionExpression) {
-    throw new UnsupportedOperationException();
-  }
-
-  public void removeSuperManagersMembership(String permissionExpression) {
-    throw new UnsupportedOperationException();
-  }
-
 }

--- a/perk-store-webapps/package-lock.json
+++ b/perk-store-webapps/package-lock.json
@@ -11,8 +11,9 @@
       "devDependencies": {
         "babel-loader": "^8.3.0",
         "eslint": "^8.12.0",
-        "eslint-config-meedsio": "^1.0.4",
+        "eslint-config-meedsio": "^1.0.5",
         "eslint-plugin-vue": "^8.6.0",
+        "eslint-plugin-vuejs-accessibility": "^2.1.0",
         "eslint-webpack-plugin": "^3.1.1",
         "vue": "^2.6.14",
         "vue-loader": "^15.10.1",
@@ -914,6 +915,15 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true
     },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
     "node_modules/babel-loader": {
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.3.0.tgz",
@@ -1263,6 +1273,15 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/doctrine": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
@@ -1279,6 +1298,12 @@
       "version": "1.4.284",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.284.tgz",
       "integrity": "sha512-M8WEXFuKXMYMVr45fo8mq0wUrrJHheiKZf6BArTKk9ZBYCKJEOU5H8cdWgDT+qCVZf7Na4lVUaZsA+h6uA9+PA==",
+      "dev": true
+    },
+    "node_modules/emoji-regex": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.3.0.tgz",
+      "integrity": "sha512-QpLs9D9v9kArv4lfDEgg1X/gN5XLnf/A6l9cs8SPZLRZR3ZkY9+kwIQTxm+fsSej5UMYGE8fdoaZVIBlqG0XTw==",
       "dev": true
     },
     "node_modules/emojis-list": {
@@ -1397,9 +1422,9 @@
       }
     },
     "node_modules/eslint-config-meedsio": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/eslint-config-meedsio/-/eslint-config-meedsio-1.0.4.tgz",
-      "integrity": "sha512-hGHNO0ss7jqPgPMQUe+q8UmA4lrIUnaqeusGeiCPYq1z9APGWNrZEIqpY8NGi2at6vcQJ0yXl559RRUeuP3GUg==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/eslint-config-meedsio/-/eslint-config-meedsio-1.0.5.tgz",
+      "integrity": "sha512-eSae9Ald7T7g4gIdomPGJ7/H+aVd9L+wLvDUICvc8vKfLeKoJSdOH1uoJ1beUytObQbzbJJJC+cHvf+8BxYDdg==",
       "dev": true
     },
     "node_modules/eslint-plugin-vue": {
@@ -1450,6 +1475,80 @@
       }
     },
     "node_modules/eslint-plugin-vue/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
+    },
+    "node_modules/eslint-plugin-vuejs-accessibility": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-vuejs-accessibility/-/eslint-plugin-vuejs-accessibility-2.2.0.tgz",
+      "integrity": "sha512-/Dr02rkrBU/mDE4+xO8/9Y230mC9ZTkh2U5tJHEFHxw/CldccmVCWgWs4NM1lq+Bbu9bJzwJPHOsZ+o5wIQuOA==",
+      "dev": true,
+      "dependencies": {
+        "aria-query": "^5.3.0",
+        "emoji-regex": "^10.0.0",
+        "vue-eslint-parser": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "eslint": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-vuejs-accessibility/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/eslint-plugin-vuejs-accessibility/node_modules/semver": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/eslint-plugin-vuejs-accessibility/node_modules/vue-eslint-parser": {
+      "version": "9.3.2",
+      "resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-9.3.2.tgz",
+      "integrity": "sha512-q7tWyCVaV9f8iQyIA5Mkj/S6AoJ9KBN8IeUSf3XEmBrOtxOZnfTg5s4KClbZBCK3GtnT/+RyCLZyDHuZwTuBjg==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.3.4",
+        "eslint-scope": "^7.1.1",
+        "eslint-visitor-keys": "^3.3.0",
+        "espree": "^9.3.1",
+        "esquery": "^1.4.0",
+        "lodash": "^4.17.21",
+        "semver": "^7.3.6"
+      },
+      "engines": {
+        "node": "^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
+      },
+      "peerDependencies": {
+        "eslint": ">=6.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-vuejs-accessibility/node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
@@ -4516,6 +4615,15 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true
     },
+    "aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "requires": {
+        "dequal": "^2.0.3"
+      }
+    },
     "babel-loader": {
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.3.0.tgz",
@@ -4777,6 +4885,12 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
     },
+    "dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true
+    },
     "doctrine": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
@@ -4790,6 +4904,12 @@
       "version": "1.4.284",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.284.tgz",
       "integrity": "sha512-M8WEXFuKXMYMVr45fo8mq0wUrrJHheiKZf6BArTKk9ZBYCKJEOU5H8cdWgDT+qCVZf7Na4lVUaZsA+h6uA9+PA==",
+      "dev": true
+    },
+    "emoji-regex": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.3.0.tgz",
+      "integrity": "sha512-QpLs9D9v9kArv4lfDEgg1X/gN5XLnf/A6l9cs8SPZLRZR3ZkY9+kwIQTxm+fsSej5UMYGE8fdoaZVIBlqG0XTw==",
       "dev": true
     },
     "emojis-list": {
@@ -4947,9 +5067,9 @@
       }
     },
     "eslint-config-meedsio": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/eslint-config-meedsio/-/eslint-config-meedsio-1.0.4.tgz",
-      "integrity": "sha512-hGHNO0ss7jqPgPMQUe+q8UmA4lrIUnaqeusGeiCPYq1z9APGWNrZEIqpY8NGi2at6vcQJ0yXl559RRUeuP3GUg==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/eslint-config-meedsio/-/eslint-config-meedsio-1.0.5.tgz",
+      "integrity": "sha512-eSae9Ald7T7g4gIdomPGJ7/H+aVd9L+wLvDUICvc8vKfLeKoJSdOH1uoJ1beUytObQbzbJJJC+cHvf+8BxYDdg==",
       "dev": true
     },
     "eslint-plugin-vue": {
@@ -4982,6 +5102,58 @@
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "dev": true
+        }
+      }
+    },
+    "eslint-plugin-vuejs-accessibility": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-vuejs-accessibility/-/eslint-plugin-vuejs-accessibility-2.2.0.tgz",
+      "integrity": "sha512-/Dr02rkrBU/mDE4+xO8/9Y230mC9ZTkh2U5tJHEFHxw/CldccmVCWgWs4NM1lq+Bbu9bJzwJPHOsZ+o5wIQuOA==",
+      "dev": true,
+      "requires": {
+        "aria-query": "^5.3.0",
+        "emoji-regex": "^10.0.0",
+        "vue-eslint-parser": "^9.0.1"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "semver": {
+          "version": "7.5.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "vue-eslint-parser": {
+          "version": "9.3.2",
+          "resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-9.3.2.tgz",
+          "integrity": "sha512-q7tWyCVaV9f8iQyIA5Mkj/S6AoJ9KBN8IeUSf3XEmBrOtxOZnfTg5s4KClbZBCK3GtnT/+RyCLZyDHuZwTuBjg==",
+          "dev": true,
+          "requires": {
+            "debug": "^4.3.4",
+            "eslint-scope": "^7.1.1",
+            "eslint-visitor-keys": "^3.3.0",
+            "espree": "^9.3.1",
+            "esquery": "^1.4.0",
+            "lodash": "^4.17.21",
+            "semver": "^7.3.6"
           }
         },
         "yallist": {


### PR DESCRIPTION
This change will delete  flag from Mocked Test classes to not have a compilation error when deleting or modifying a fake method implementation from IdentityManager and SpaceService. In addition, this will cleanup useless methods implemented in Mocked Social Classes.