### PR TITLE
feat: Cleanup Dependencies to rely on Spring Dependencies Tree - Meeds-io/MIPs#57

### DIFF
--- a/perk-store-services/pom.xml
+++ b/perk-store-services/pom.xml
@@ -29,7 +29,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     <rest.api.doc.version>1.0</rest.api.doc.version>
     <rest.api.doc.description>Perk Store addon rest endpoints</rest.api.doc.description>
 
-    <exo.test.coverage.ratio>0.61</exo.test.coverage.ratio>
+    <exo.test.coverage.ratio>0.53</exo.test.coverage.ratio>
   </properties>
   <dependencies>
     <dependency>

--- a/perk-store-services/src/main/java/org/exoplatform/perkstore/dao/PerkStoreOrderDAO.java
+++ b/perk-store-services/src/main/java/org/exoplatform/perkstore/dao/PerkStoreOrderDAO.java
@@ -24,9 +24,9 @@ import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
 import java.util.*;
 
-import javax.persistence.TypedQuery;
+import jakarta.persistence.TypedQuery;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import org.exoplatform.commons.persistence.impl.GenericDAOJPAImpl;
 import org.exoplatform.perkstore.entity.ProductOrderEntity;

--- a/perk-store-services/src/main/java/org/exoplatform/perkstore/dao/PerkStoreProductDAO.java
+++ b/perk-store-services/src/main/java/org/exoplatform/perkstore/dao/PerkStoreProductDAO.java
@@ -18,7 +18,7 @@ package org.exoplatform.perkstore.dao;
 
 import java.util.List;
 
-import javax.persistence.TypedQuery;
+import jakarta.persistence.TypedQuery;
 
 import org.exoplatform.commons.persistence.impl.GenericDAOJPAImpl;
 import org.exoplatform.perkstore.entity.ProductEntity;

--- a/perk-store-services/src/main/java/org/exoplatform/perkstore/entity/ProductEntity.java
+++ b/perk-store-services/src/main/java/org/exoplatform/perkstore/entity/ProductEntity.java
@@ -20,7 +20,7 @@ import java.io.Serializable;
 import java.util.List;
 import java.util.Set;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 
 import org.exoplatform.commons.api.persistence.ExoEntity;
 import org.exoplatform.perkstore.model.constant.ProductOrderPeriodType;

--- a/perk-store-services/src/main/java/org/exoplatform/perkstore/entity/ProductOrderEntity.java
+++ b/perk-store-services/src/main/java/org/exoplatform/perkstore/entity/ProductOrderEntity.java
@@ -18,7 +18,7 @@ package org.exoplatform.perkstore.entity;
 
 import java.io.Serializable;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 
 import org.exoplatform.commons.api.persistence.ExoEntity;
 import org.exoplatform.perkstore.model.constant.ProductOrderStatus;

--- a/perk-store-services/src/main/java/org/exoplatform/perkstore/model/constant/PerkStoreError.java
+++ b/perk-store-services/src/main/java/org/exoplatform/perkstore/model/constant/PerkStoreError.java
@@ -21,7 +21,7 @@ import static org.exoplatform.perkstore.service.utils.Utils.*;
 import java.io.Serializable;
 import java.text.MessageFormat;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.helpers.MessageFormatter;
 
 public enum PerkStoreError {

--- a/perk-store-services/src/main/java/org/exoplatform/perkstore/service/PerkStoreService.java
+++ b/perk-store-services/src/main/java/org/exoplatform/perkstore/service/PerkStoreService.java
@@ -27,7 +27,7 @@ import java.time.LocalDateTime;
 import java.util.*;
 import java.util.stream.Collectors;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.picocontainer.Startable;
 
 import org.exoplatform.commons.api.settings.SettingService;

--- a/perk-store-services/src/main/java/org/exoplatform/perkstore/service/utils/NotificationUtils.java
+++ b/perk-store-services/src/main/java/org/exoplatform/perkstore/service/utils/NotificationUtils.java
@@ -22,7 +22,7 @@ import static org.exoplatform.perkstore.service.utils.Utils.*;
 
 import java.util.*;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import org.exoplatform.commons.api.notification.NotificationContext;
 import org.exoplatform.commons.api.notification.channel.template.TemplateProvider;

--- a/perk-store-services/src/main/resources/db/changelog/perkstore-rdbms.db.changelog-1.0.0.xml
+++ b/perk-store-services/src/main/resources/db/changelog/perkstore-rdbms.db.changelog-1.0.0.xml
@@ -181,6 +181,8 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   </changeSet>
 
   <changeSet author="perkstore" id="1.0.0-11">
+    <validCheckSum>8:0c254d780bc77fd5448845d21e98004d</validCheckSum>
+    <validCheckSum>8:d41d8cd98f00b204e9800998ecf8427e</validCheckSum>
     <sql dbms="postgresql" >
       ALTER TABLE ADDONS_PERKSTORE_PRODUCT ALTER COLUMN DELETED DROP DEFAULT;
       ALTER TABLE ADDONS_PERKSTORE_PRODUCT ALTER DELETED TYPE bool USING DELETED::boolean;

--- a/perk-store-webapps/src/main/webapp/WEB-INF/conf/perk-store/templates/notification/mail/OrderMailPlugin.gtmpl
+++ b/perk-store-webapps/src/main/webapp/WEB-INF/conf/perk-store/templates/notification/mail/OrderMailPlugin.gtmpl
@@ -61,7 +61,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
                                         } else {
                                          String modifierLink = "<a class=\"user-name text-bold\" href=\"javascript:void(0)\">" + modifierName + "</a>";
                                          String key = "Notification.perkstore.order.modified." + orderStatusLabel;
-                                         if (org.apache.commons.lang.StringUtils.isBlank(modifierName)) {
+                                         if (org.apache.commons.lang3.StringUtils.isBlank(modifierName)) {
                                            // System modification
                                            key += ".system";
                                          }
@@ -81,7 +81,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
                                                     <p style="margin: 5px 0; line-height: 16px; font-family: HelveticaNeue, Helvetica, Arial, sans-serif">
                                                       <%= _ctx.appRes("Notification.perkstore.order.status") %>: <%= orderStatus %>
                                                     </p>
-                                                    <% if(org.apache.commons.lang.StringUtils.equalsIgnoreCase(orderStatus, "error")) { %>
+                                                    <% if(org.apache.commons.lang3.StringUtils.equalsIgnoreCase(orderStatus, "error")) { %>
                                                       <p style="margin: 5px 0; line-height: 16px; font-family: HelveticaNeue, Helvetica, Arial, sans-serif">
                                                         <%= _ctx.appRes("Notification.perkstore.order.error") %>
                                                       </p>
@@ -89,17 +89,17 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
                                                     <p style="margin: 5px 0; line-height: 16px; font-family: HelveticaNeue, Helvetica, Arial, sans-serif">
                                                       <%= _ctx.appRes("Notification.perkstore.order.quantity") %>: <%= orderQuantity %>
                                                     </p>
-                                                    <% if(org.apache.commons.lang.StringUtils.isNotBlank(orderDeliveredQuantity) && !org.apache.commons.lang.StringUtils.equalsIgnoreCase(orderDeliveredQuantity, "0")) { %>
+                                                    <% if(org.apache.commons.lang3.StringUtils.isNotBlank(orderDeliveredQuantity) && !org.apache.commons.lang3.StringUtils.equalsIgnoreCase(orderDeliveredQuantity, "0")) { %>
                                                       <p style="margin: 5px 0; line-height: 16px; font-family: HelveticaNeue, Helvetica, Arial, sans-serif">
                                                         <%= _ctx.appRes("Notification.perkstore.order.deliveredQuantity") %>: <%= orderDeliveredQuantity %>
                                                       </p>
                                                     <% } %>
-                                                    <% if(org.apache.commons.lang.StringUtils.isNotBlank(orderRefundedQuantity) && !org.apache.commons.lang.StringUtils.equalsIgnoreCase(orderRefundedQuantity, "0")) { %>
+                                                    <% if(org.apache.commons.lang3.StringUtils.isNotBlank(orderRefundedQuantity) && !org.apache.commons.lang3.StringUtils.equalsIgnoreCase(orderRefundedQuantity, "0")) { %>
                                                       <p style="margin: 5px 0; line-height: 16px; font-family: HelveticaNeue, Helvetica, Arial, sans-serif">
                                                         <%= _ctx.appRes("Notification.perkstore.order.refundedQuantity") %>: <%= orderRefundedQuantity %>
                                                       </p>
                                                     <% } %>
-                                                    <% if(org.apache.commons.lang.StringUtils.isNotBlank(orderRemainingQuantity) && !org.apache.commons.lang.StringUtils.equalsIgnoreCase(orderRemainingQuantity, "0")) { %>
+                                                    <% if(org.apache.commons.lang3.StringUtils.isNotBlank(orderRemainingQuantity) && !org.apache.commons.lang3.StringUtils.equalsIgnoreCase(orderRemainingQuantity, "0")) { %>
                                                       <p style="margin: 5px 0; line-height: 16px; font-family: HelveticaNeue, Helvetica, Arial, sans-serif">
                                                         <%= _ctx.appRes("Notification.perkstore.order.remainingQuantity") %>: <%= orderRemainingQuantity %>
                                                       </p>

--- a/perk-store-webapps/src/main/webapp/WEB-INF/conf/perk-store/templates/notification/mail/ProductMailPlugin.gtmpl
+++ b/perk-store-webapps/src/main/webapp/WEB-INF/conf/perk-store/templates/notification/mail/ProductMailPlugin.gtmpl
@@ -67,7 +67,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
                                         <tbody>
                                             <tr>
                                                 <td align="left" bgcolor="#ffffff" style="background-color: #f9f9f9; padding: 15px 20px;">
-                                                    <% if(org.apache.commons.lang.StringUtils.isNotBlank(productSupply) && !org.apache.commons.lang.StringUtils.equals(productSupply, "0")) { %>
+                                                    <% if(org.apache.commons.lang3.StringUtils.isNotBlank(productSupply) && !org.apache.commons.lang3.StringUtils.equals(productSupply, "0")) { %>
                                                       <p style="margin: 5px 0; line-height: 16px; font-family: HelveticaNeue, Helvetica, Arial, sans-serif">
                                                         <%= _ctx.appRes("Notification.perkstore.product.supply") %>: <%= productSupply %>
                                                       </p>

--- a/perk-store-webapps/src/main/webapp/WEB-INF/conf/perk-store/templates/notification/push/OrderPushPlugin.gtmpl
+++ b/perk-store-webapps/src/main/webapp/WEB-INF/conf/perk-store/templates/notification/push/OrderPushPlugin.gtmpl
@@ -20,7 +20,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     message = _ctx.appRes("Notification.perkstore.order.created", senderName, orderQuantity, productTitle);
   } else {
     String key = "Notification.perkstore.order.modified." + orderStatusLabel;
-    if (org.apache.commons.lang.StringUtils.isBlank(modifierName)) {
+    if (org.apache.commons.lang3.StringUtils.isBlank(modifierName)) {
       // System modification
       key += ".system";
     }


### PR DESCRIPTION
This change will upgrade from Commons Lang to Apache Lang 3 and will recompute the score of Tests coverage after excluding globally the POJOs from computation scopre computing. ( see Meeds-io/maven-parent-pom#45 )

(Resolves Meeds-io/MIPs#57)