### PR TITLE
feat: Redefine Parent applications Classes to fit layout style properties - MEED-7094 - Meeds-io/MIPs#144

### DIFF
--- a/perk-store-webapps/src/main/webapp/vue-app/components/PerkStoreApp.vue
+++ b/perk-store-webapps/src/main/webapp/vue-app/components/PerkStoreApp.vue
@@ -20,7 +20,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     class="transparent singlePageApplication"
     flat>
     <wallet-notification-alert />
-    <main v-if="loading">
+    <main v-if="loading" class="application-body">
       <v-toolbar color="transparent" flat>
         <v-spacer />
         <v-progress-circular
@@ -30,18 +30,18 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
         <v-spacer />
       </v-toolbar>
     </main>
-    <main v-else>
+    <main v-else class="application-body">
       <template>
         <div class="application-toolbar">
           <v-tabs
             v-model="tab"
             slider-size="4"
-            class="card-border-radius overflow-hidden">
+            class="application-body">
             <v-tab @click="refreshProductList">{{ $t('exoplatform.perkstore.label.Catalogue') }}</v-tab>
             <v-tab @click="displayMyOrdersList">{{ $t('exoplatform.perkstore.label.MyOrders') }}</v-tab>
           </v-tabs>
           <v-tabs-items v-model="tab" class="tabs-content card-border-radius">
-            <v-tab-item class="product-list pa-4 card-border-radius overflow-hidden" eager>
+            <v-tab-item class="product-list pa-4 application-body" eager>
               <perk-store-toolbar 
                 :can-add-product="userSettings.canAddProduct"
                 :symbol="symbol"


### PR DESCRIPTION
This change will apply **application-body** class to the main body of applications to make sure to apply layout specific CSS styles, such as disabling default Vuetify White Background applied on v-card. At the same time, for Top Toolbar applications, this will disable branding styling to avoid having border radius and other styles applied on small buttons added in Top bar as applications.