### PR TITLE
feat: Rename Social Web Archive to social - Meeds-io/MIPs#150

### DIFF
--- a/perk-store-webapps/src/main/webapp/WEB-INF/gatein-resources.xml
+++ b/perk-store-webapps/src/main/webapp/WEB-INF/gatein-resources.xml
@@ -33,7 +33,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   </portlet-skin>
 
   <portlet-skin>
-    <application-name>social-portlet</application-name>
+    <application-name>social</application-name>
     <portlet-name>Search</portlet-name>
     <skin-name>Enterprise</skin-name>
     <additional-module>perkstore</additional-module>


### PR DESCRIPTION
This change will rename the Social Web Archive from social-portlet to social.